### PR TITLE
Expose iframe height

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -413,6 +413,15 @@ export class MeetergoIntegration {
 
     return button;
   }
+
+  private postScrollHeightToParent(scrollHeight: number): void {
+    window.parent.postMessage({ scrollHeight: scrollHeight }, "*");
+  }
+  
+  public sendScrollHeightToParent(): void {
+    const scrollHeight = document.body.scrollHeight;
+    this.postScrollHeightToParent(scrollHeight);
+  }
 }
 
 export const meetergo = new MeetergoIntegration();


### PR DESCRIPTION
Currently, we cannot access the iframe height programatically due to the sandbox restrictions in iframe. Something like this would enable us to adapt the iframe height every time it changes the internal page, so our wrapper can adapt to it without accesing `iframe.contentWindow?.document.body.scrollHeight`