### PR TITLE
fix: accept all meetergo.com subdomains for iframe height messages

### DIFF
--- a/src/utils/iframe-height.ts
+++ b/src/utils/iframe-height.ts
@@ -26,16 +26,6 @@ const DEFAULT_CONFIG: Required<HeightUpdateConfig> = {
 };
 
 /**
- * Valid meetergo origins for message validation
- */
-const VALID_MEETERGO_ORIGINS = [
-  'https://cal.meetergo.com',
-  'https://meetergo.com',
-  'https://www.meetergo.com',
-  'https://app.meetergo.com',
-];
-
-/**
  * Check if origin is a valid meetergo domain
  */
 export function isValidMeetergoOrigin(origin: string): boolean {
@@ -43,7 +33,8 @@ export function isValidMeetergoOrigin(origin: string): boolean {
   if (origin.includes('localhost') || origin.includes('127.0.0.1')) {
     return true;
   }
-  return VALID_MEETERGO_ORIGINS.some((validOrigin) => origin === validOrigin || origin.startsWith(validOrigin));
+  // Accept all *.meetergo.com subdomains (cal, my, www, etc.)
+  return origin === 'https://meetergo.com' || (origin.endsWith('.meetergo.com') && origin.startsWith('https://'));
 }
 
 /**


### PR DESCRIPTION
The origin validation list was missing my.meetergo.com, causing popup modals to stay stuck at min-height 400px and flash white when loading forms from that subdomain. Replace hardcoded list with wildcard check for all *.meetergo.com subdomains.