### PR TITLE
fix(v4): fire onSuccess/onBookingSuccessful on booking completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Paste the loader snippet into `<head>` — that's it:
     w.meetergo.version = '4';
     var e = d.createElement(s); e.async = 1; e.src = u;
     d.head.appendChild(e);
-  })(window, document, 'script', 'https://liv-showcase.s3.eu-central-1.amazonaws.com/browser-v4.js');
+  })(window, document, 'script', 'https://cdn.meetergo.com/v4/integration.js');
 
   meetergo('init', {
     onBookingSuccessful: function(data) {
@@ -358,7 +358,7 @@ v4 is backwards compatible — no immediate changes required. To adopt the new A
     w.meetergo.version = '4';
     var e = d.createElement(s); e.async = 1; e.src = u;
     d.head.appendChild(e);
-  })(window, document, 'script', 'https://liv-showcase.s3.eu-central-1.amazonaws.com/browser-v4.js');
+  })(window, document, 'script', 'https://cdn.meetergo.com/v4/integration.js');
 
   meetergo('init', {
     floatingButton: { link: '...', position: 'bottom-right' },
@@ -399,13 +399,20 @@ The test page (`test-v4.html`) covers all embed types: inline, modal, sidebar, f
 
 ## CDN
 
-```html
-<!-- v4 (current) -->
-<script src="https://liv-showcase.s3.eu-central-1.amazonaws.com/browser-v4.js"></script>
+The canonical, always-latest build is served from Bunny. Use this URL for all
+new integrations:
 
-<!-- v3 (legacy) -->
-<script src="https://liv-showcase.s3.eu-central-1.amazonaws.com/browser-v3.js"></script>
+```html
+<!-- v4 (current, canonical) -->
+<script src="https://cdn.meetergo.com/v4/integration.js"></script>
 ```
+
+> **Deprecated mirrors — do not use for new setups.** The old S3 URLs
+> (`liv-showcase.s3.eu-central-1.amazonaws.com/browser-v2.js` / `browser-v3.js` /
+> `browser-v4.js`) are legacy and are no longer the source of truth. They remain
+> reachable only so existing embeds keep working. `browser-v4.js` is the same v4
+> build as the canonical URL and must be kept in sync on every release until it
+> is retired; `browser-v3.js`/`browser-v2.js` are the pre-v4 generation.
 
 ---
 

--- a/src/v4/core/namespace.ts
+++ b/src/v4/core/namespace.ts
@@ -42,6 +42,7 @@ import type {
   EventHandler,
   WildcardHandler,
   NamespaceHandle,
+  BookingSuccessfulData,
 } from "../types/index.js";
 
 export class MeetergoNamespace {
@@ -178,6 +179,18 @@ export class MeetergoNamespace {
 
   once<E extends MeetergoEvent>(event: E["event"], handler: EventHandler<E>): void {
     this.bus.once(event, handler as Parameters<EventBus["once"]>[1]);
+  }
+
+  /**
+   * Bridge a raw `booking-successful` postMessage (sent by the booking iframe)
+   * onto the typed bus, so `onSuccess`, `onBookingSuccessful` and
+   * `on("bookingSuccessful")` subscribers fire. Invoked by the SDK's global
+   * message listener; the iframe message carries no namespace, so the SDK
+   * broadcasts to every live namespace.
+   */
+  emitBookingSuccessful(data: BookingSuccessfulData): void {
+    if (this.destroyed) return;
+    this.bus.emit("bookingSuccessful", data);
   }
 
   /** Live-update UI / theme for all iframes in this namespace. */

--- a/src/v4/core/sdk.ts
+++ b/src/v4/core/sdk.ts
@@ -20,6 +20,7 @@ import type {
   MeetergoPrefill,
   UiConfig,
   InlineEmbedConfig,
+  BookingSuccessfulData,
 } from "../types/index.js";
 
 export const SDK_VERSION = "4.0.0";
@@ -85,6 +86,20 @@ export class MeetergoSDK {
         const link = payload?.link ?? "";
         if (!link) return;
         this.getOrCreate(DEFAULT_NS).openModal(link, payload?.params);
+        return;
+      }
+
+      // Booking completed inside an embedded iframe. The booking page posts
+      // { event: "booking-successful", data } to its parent; bridge it onto the
+      // typed bus so onSuccess / onBookingSuccessful subscribers fire. The
+      // message carries no namespace, so broadcast to every live namespace
+      // (mirrors the single global handler v3 used for meetergoSettings.onSuccess).
+      if (data.event === "booking-successful") {
+        const payload = (data.data ?? {}) as BookingSuccessfulData;
+        for (const ns of this.namespaces.values()) {
+          ns.emitBookingSuccessful(payload);
+        }
+        return;
       }
     });
   }


### PR DESCRIPTION
## Problem

The v4 SDK never fires the booking-success callback. `onSuccess`, `onBookingSuccessful`, and `on("bookingSuccessful")` are all subscribed to the internal bus event `bookingSuccessful`, but **nothing ever emits it**. The global `message` listener (`src/v4/core/sdk.ts`) only handled `open-modal` and ignored the `{ event: "booking-successful", data }` message that the booking iframe posts to its parent.

This is a regression from v3 (`src/main.ts` had the `case "booking-successful": … onSuccess(data)` bridge). v4 has shipped without it since its first commit, so **every v4 integration relying on the success callback has been silently broken** — reported by a customer whose `meetergoSettings.onSuccess` tracking never ran (booking itself succeeds).

## Fix

- `sdk.ts` global listener: on a `booking-successful` message, emit `bookingSuccessful` on **every live namespace** (the message carries no namespace, mirroring v3's single global handler for `meetergoSettings.onSuccess`).
- `namespace.ts`: expose `emitBookingSuccessful(data)` to bridge the raw message onto the typed bus.
- README: point the canonical CDN URL at the Bunny build (`cdn.meetergo.com/v4/integration.js`) and mark the S3 `browser-*.js` mirrors deprecated, so new setups stop copying straggler URLs.

## Verification

Built the ultra bundle and drove it in a browser with the exact customer setup (legacy `window.meetergoSettings.onSuccess`) and the exact message the booking iframe sends:

- ✅ legacy `meetergoSettings.onSuccess` fires with the full booking payload
- ✅ new `meetergo('on', { action: 'bookingSuccessful' })` API also fires
- ✅ unrelated messages (`open-modal`, `meetergo:page_height`, arbitrary) do **not** fire it

## Deploy notes

- `npm run deploy-v4-prod` publishes to Bunny (`cdn.meetergo.com/v4/integration.js`) — the canonical build.
- The S3 straggler `s3://liv-showcase/browser-v4.js` is the same v4 source and is still live for existing embeds; it must be re-uploaded with this build too, or those consumers stay broken. `browser-v3.js`/`browser-v2.js` (pre-v4) already fire onSuccess and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)