### PR TITLE
fix(v4): forward marketing/attribution params (UTMs) by default

### DIFF
--- a/src/v4/types/index.ts
+++ b/src/v4/types/index.ts
@@ -278,7 +278,16 @@ export interface NamespaceConfig {
   /** Global prefill for all embeds in this namespace */
   prefill?: MeetergoPrefill;
 
-  /** Forward current page query params to iframes (opt-in) */
+  /**
+   * Forward parent-page query params to booking iframes.
+   *
+   *   - unset      → forward the marketing/attribution family only
+   *                  (utm_*, fbclid, gclid, ttclid, …) so ad tracking works
+   *                  out of the box
+   *   - `true`     → forward every param (except reserved booking params)
+   *   - `string[]` → forward only the listed params
+   *   - `false`    → forward nothing
+   */
   forwardQueryParams?: boolean | string[];
 
   /** Floating button configuration */

--- a/src/v4/utils/url-params.ts
+++ b/src/v4/utils/url-params.ts
@@ -17,6 +17,33 @@ const RESERVED_PARAMS = new Set([
 ]);
 
 /**
+ * Marketing / attribution params forwarded by default when the embedder
+ * has not configured `forwardQueryParams` explicitly.
+ *
+ * Before v4 the embed script forwarded *every* parent-page query param to the
+ * booking iframe automatically, so ad-campaign attribution (UTMs, click IDs)
+ * flowed through to the booking and any post-booking redirect without setup.
+ * v4 made forwarding fully opt-in, which silently broke that attribution for
+ * existing embeds. Restoring a conservative default — the well-known marketing
+ * param family — keeps tracking working out of the box while still not leaking
+ * arbitrary parent-page params (use `forwardQueryParams: true` for that).
+ */
+const DEFAULT_FORWARD_PARAMS = new Set([
+  // UTM (Google/analytics standard)
+  "utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term",
+  "utm_id",
+  // Ad-platform click identifiers
+  "fbclid",    // Meta / Facebook
+  "gclid", "gbraid", "wbraid", "gad_source", // Google Ads
+  "msclkid",   // Microsoft Ads
+  "ttclid",    // TikTok
+  "twclid",    // X / Twitter
+  "li_fat_id", // LinkedIn
+  "igshid",    // Instagram
+  "epik",      // Pinterest
+]);
+
+/**
  * Build a full iframe src URL from a base link + params.
  */
 export function buildIframeURL(
@@ -71,16 +98,26 @@ export function collectIframeParams(options: {
     Object.assign(result, options.extraParams);
   }
 
-  // 3. Forward parent-page query params (opt-in)
-  if (options.forwardQueryParams && typeof window !== "undefined") {
+  // 3. Forward parent-page query params.
+  //
+  //   - unset       → forward the marketing/attribution family (default, so
+  //                    ad tracking keeps working out of the box)
+  //   - `true`      → forward every param (except reserved)
+  //   - `string[]`  → forward only the listed params
+  //   - `false`     → forward nothing
+  const forward = options.forwardQueryParams;
+  if (forward !== false && typeof window !== "undefined") {
     const pageParams = new URLSearchParams(window.location.search);
     pageParams.forEach((value, key) => {
       if (RESERVED_PARAMS.has(key)) return;
 
-      const forward = options.forwardQueryParams;
-      if (forward === true) {
-        result[key] = value;
-      } else if (Array.isArray(forward) && forward.includes(key)) {
+      const shouldForward =
+        forward === true
+          ? true
+          : Array.isArray(forward)
+            ? forward.includes(key)
+            : DEFAULT_FORWARD_PARAMS.has(key); // unset → marketing default
+      if (shouldForward) {
         result[key] = value;
       }
     });


### PR DESCRIPTION
## Problem

The pre-v4 embed script forwarded **every** parent-page query param into the booking iframe automatically. So when a booking is embedded on a landing/funnel page, ad-campaign parameters (UTMs, `fbclid`, `gclid`, …) flowed through to the booking — and from there into notes/CRM and any post-booking redirect (e.g. a "danke" page) — with **zero configuration**.

v4 changed forwarding to be **fully opt-in** via `forwardQueryParams` (default off). For every embed that relied on the old automatic behavior, this silently broke attribution the moment the embed started loading the v4 script: UTMs stopped arriving at the booking page, so they were neither stored nor passed to the redirect target.

This was diagnosed from a customer report ("UTM forwarding worked, then suddenly stopped"). Their bookings captured UTMs in `notes` through late May and dropped to **zero** right as their embed moved to v4 — the signature of auto-forward → opt-in. The booking app itself preserves and forwards UTMs correctly when they're present on the URL; the params simply never reached the iframe.

## Fix

When `forwardQueryParams` is **unset**, forward a conservative default: the well-known marketing/attribution family (`utm_*`, `fbclid`, `gclid`, `gbraid`, `wbraid`, `gad_source`, `msclkid`, `ttclid`, `twclid`, `li_fat_id`, `igshid`, `epik`).

Explicit modes are unchanged:

| `forwardQueryParams` | Behavior |
|---|---|
| unset | **marketing/attribution family** (new default) |
| `true` | all params except reserved |
| `string[]` | only the listed params |
| `false` | nothing |

Reserved booking params (`embed`, `month`, `date`, `slot`, `rescheduleUid`, `bookingUid`, `redirect_url`, `ns`) are still never forwarded. This restores out-of-the-box tracking without reintroducing forward-everything-by-default (use `true` for that).

## Verification

The repo has no wired test harness (no jest config / deps), so I transpiled `src/v4/utils/url-params.ts` with esbuild and exercised every mode against a stubbed `window.location.search`:

- unset → `{utm_source, fbclid}` (drops `embed`, arbitrary `foo`, `sessionSecret`)
- `true` → all-but-reserved (`embed` dropped, `foo`/`sessionSecret` kept)
- `['utm_source','foo']` → only those two
- `false` / `[]` → `{}`
- reserved never forwarded even if allow-listed

## Deploy note

This ships via `deploy-v4-prod` (build + upload to the CDN) — that job must be run after merge for existing embeds to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)