### PR TITLE
fix(deploy): publish every rolling entry point, and make the deploy script runnable

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "esbuild-v4-browser:dev": "esbuild src/v4/browser.ts --bundle --sourcemap=inline --outfile=dist/v4/browser.js",
     "esbuild-v4-browser:watch": "esbuild src/v4/browser.ts --bundle --watch --sourcemap=inline --outfile=dist/v4/browser.js",
     "esbuild-v4-esm": "esbuild src/v4/index.ts --bundle --format=esm --external:react --external:react-dom --minify --outfile=dist/v4/index.esm.js",
-    "deploy-v4-prod": "npm run build-v4 && curl -fsS -X PUT -H \"AccessKey: $BUNNY_CDN_STORAGE_KEY\" --data-binary @dist/v4/browser-ultra.js \"https://storage.bunnycdn.com/meetergo-cdn-prod/v4/integration.js\" && curl -fsS -X POST \"https://api.bunny.net/purge?url=https://cdn.meetergo.com/v4/integration.js\" -H \"AccessKey: $BUNNY_API_KEY\""
+    "deploy-v4-prod": "npm run build-v4 && bash scripts/deploy-cdn.sh"
   },
   "dependencies": {
     "esbuild": "^0.25.1"

--- a/scripts/deploy-cdn.sh
+++ b/scripts/deploy-cdn.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Publish the v4 embed bundle to every rolling entry point on the CDN.
+#
+# Why more than one path: customers hardcode the script URL in their pages, so
+# an entry point can never be retired — it can only stop receiving updates.
+# Every path listed in ENTRYPOINTS must therefore get every release. Shipping
+# to only one of them is what caused the UTM-forwarding incident: a customer
+# was moved to a new path and then silently stopped receiving fixes.
+#
+# Auth: BUNNYNET_API_KEY is the Bunny *account* key (same one Terraform uses).
+# The storage-zone password is derived from it at run time, so there is no
+# second secret to keep in sync. The previous version of this script expected
+# BUNNY_CDN_STORAGE_KEY / BUNNY_API_KEY, which were never set anywhere — it
+# could not run as written.
+set -euo pipefail
+
+ZONE="meetergo-cdn-prod"
+BUNDLE="dist/v4/browser-ultra.js"
+ENTRYPOINTS=("v4/integration.js" "v5/integration.js")
+
+: "${BUNNYNET_API_KEY:?BUNNYNET_API_KEY is required (Bunny account API key)}"
+
+[ -f "$BUNDLE" ] || { echo "missing $BUNDLE — run 'npm run build-v4' first" >&2; exit 1; }
+
+storage_key=$(
+  curl -fsS -H "AccessKey: ${BUNNYNET_API_KEY}" -H "Accept: application/json" \
+    "https://api.bunny.net/storagezone?page=1&perPage=1000" |
+  python3 -c "import sys,json;d=json.load(sys.stdin);i=d.get('Items',d) if isinstance(d,dict) else d;print(next((z['Password'] for z in i if z.get('Name')=='${ZONE}'),''))"
+)
+[ -n "$storage_key" ] || { echo "could not resolve storage key for ${ZONE}" >&2; exit 1; }
+
+for path in "${ENTRYPOINTS[@]}"; do
+  echo "→ uploading ${path}"
+  curl -fsS -X PUT -H "AccessKey: ${storage_key}" --data-binary "@${BUNDLE}" \
+    "https://storage.bunnycdn.com/${ZONE}/${path}" >/dev/null
+  echo "→ purging ${path}"
+  curl -fsS -X POST -H "AccessKey: ${BUNNYNET_API_KEY}" \
+    "https://api.bunny.net/purge?url=https://cdn.meetergo.com/${path}" >/dev/null
+done
+
+echo "verifying..."
+local_size=$(wc -c <"$BUNDLE" | tr -d ' ')
+for path in "${ENTRYPOINTS[@]}"; do
+  live_size=$(curl -fsS "https://cdn.meetergo.com/${path}" | wc -c | tr -d ' ')
+  if [ "$live_size" = "$local_size" ]; then
+    echo "  ok  ${path} (${live_size} bytes)"
+  else
+    echo "  FAIL ${path}: live ${live_size} != built ${local_size}" >&2; exit 1
+  fi
+done
+echo "done — all entry points serving the current build"


### PR DESCRIPTION
## Why

Follow-up to the UTM-forwarding incident, where three correct code fixes never reached the customer. Two defects in `deploy-v4-prod` contributed:

**1. It published to one path only.** Customers hardcode the script URL in their pages, so an entry point can never be retired — it can only stop receiving updates. Every path we have handed out must get every release. A customer moved to a different entry point would silently stop receiving fixes.

**2. It could not run as written.** It referenced `BUNNY_CDN_STORAGE_KEY` and `BUNNY_API_KEY`, neither of which is set anywhere. The only stored credential is `BUNNYNET_API_KEY` (Bunny account key, shared with Terraform). Releases were being pushed by hand.

## Change

`scripts/deploy-cdn.sh`:
- derives the storage-zone password from the account key at run time — no second secret to keep in sync
- uploads + purges **every** path in `ENTRYPOINTS` (`v4/integration.js`, `v5/integration.js`)
- verifies each live URL matches the built bundle's byte count and exits non-zero on mismatch

## Verified

Run against production:

```
→ uploading v4/integration.js
→ purging v4/integration.js
→ uploading v5/integration.js
→ purging v5/integration.js
verifying...
  ok  v4/integration.js (59615 bytes)
  ok  v5/integration.js (59615 bytes)
done — all entry points serving the current build
```

## Related

Paired with the Bunny edge-rule fix (applied): `/v<N>/integration.js` now serves `max-age=300, must-revalidate` instead of `immutable, max-age=1y`, so releases actually propagate to browsers. Previously a mutable file was served under an immutable cache, making every fix invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)